### PR TITLE
abort if KUBE_VERSION unset

### DIFF
--- a/kube-apiserver/Makefile
+++ b/kube-apiserver/Makefile
@@ -1,3 +1,6 @@
+ifndef KUBE_VERSION
+$(error Aborting, KUBE_VERSION is not set.)
+endif
 
 kube-apiserver_$(KUBE_VERSION)_amd64.snap: kube-apiserver_$(KUBE_VERSION) snapcraft.yaml
 	@cp kube-apiserver_$(KUBE_VERSION) kube-apiserver

--- a/kube-controller-manager/Makefile
+++ b/kube-controller-manager/Makefile
@@ -1,3 +1,6 @@
+ifndef KUBE_VERSION
+$(error Aborting, KUBE_VERSION is not set.)
+endif
 
 kube-controller-manager_$(KUBE_VERSION)_amd64.snap: snapcraft.yaml kube-controller-manager_$(KUBE_VERSION)
 	@cp kube-controller-manager_$(KUBE_VERSION) kube-controller-manager

--- a/kube-proxy/Makefile
+++ b/kube-proxy/Makefile
@@ -1,3 +1,6 @@
+ifndef KUBE_VERSION
+$(error Aborting, KUBE_VERSION is not set.)
+endif
 
 kube-proxy_$(KUBE_VERSION)_amd64.snap: snapcraft.yaml kube-proxy_$(KUBE_VERSION)
 	@cp kube-proxy_$(KUBE_VERSION) kube-proxy

--- a/kube-scheduler/Makefile
+++ b/kube-scheduler/Makefile
@@ -1,3 +1,6 @@
+ifndef KUBE_VERSION
+$(error Aborting, KUBE_VERSION is not set.)
+endif
 
 kube-scheduler_$(KUBE_VERSION)_amd64.snap: snapcraft.yaml kube-scheduler_$(KUBE_VERSION)
 	@cp kube-scheduler_$(KUBE_VERSION) kube-scheduler

--- a/kubectl/Makefile
+++ b/kubectl/Makefile
@@ -1,3 +1,6 @@
+ifndef KUBE_VERSION
+$(error Aborting, KUBE_VERSION is not set.)
+endif
 
 kubectl_$(KUBE_VERSION)_amd64.snap: snapcraft.yaml kubectl_$(KUBE_VERSION)
 	@cp kubectl_$(KUBE_VERSION) kubectl

--- a/kubelet/Makefile
+++ b/kubelet/Makefile
@@ -1,3 +1,6 @@
+ifndef KUBE_VERSION
+$(error Aborting, KUBE_VERSION is not set.)
+endif
 
 kubelet_$(KUBE_VERSION)_amd64.snap: snapcraft.yaml kubelet_$(KUBE_VERSION)
 	@cp kubelet_$(KUBE_VERSION) kubelet


### PR DESCRIPTION
@Cynerva avoids creation of spurious kube*_blank files if the user builds in a snap dir without setting KUBE_VERSION.